### PR TITLE
MVVM improvements

### DIFF
--- a/src/SampleCRM/Helpers/AsyncHelper.cs
+++ b/src/SampleCRM/Helpers/AsyncHelper.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using OpenRiaServices.DomainServices.Client;
+using System;
 using System.Threading.Tasks;
 
 namespace SampleCRM.Web.Views
 {
-    public class AsyncHelper
+    public static class AsyncHelper
     {
         public static IBusyCapablePage ContentPage { get; set; }
 
@@ -16,21 +17,33 @@ namespace SampleCRM.Web.Views
         {
             try
             {
-                if (ContentPage != null)
-                    ContentPage.MakeBusy(true);
+                MakeBusy(true);
 
                 await action();
 
-                if (ContentPage != null)
-                    ContentPage.MakeBusy(false);
+                MakeBusy(false);
             }
             catch (Exception ex)
             {
-                if (ContentPage != null)
-                    ContentPage.MakeBusy(false);
+                MakeBusy(false);
 
                 throw ex;
             }
+        }
+
+        public static void MakeBusy(bool busy)
+        {
+            ContentPage?.MakeBusy(busy);
+        }
+
+        public static void Load<TEntity>(this DomainContext context, EntityQuery<TEntity> query, Action<LoadOperation<TEntity>> callback) where TEntity : Entity
+        {
+            MakeBusy(true);
+            context.Load(query, result =>
+            {
+                callback(result);
+                MakeBusy(false);
+            }, null);
         }
     }
 }

--- a/src/SampleCRM/Models/CategoriesPageVM.cs
+++ b/src/SampleCRM/Models/CategoriesPageVM.cs
@@ -4,7 +4,6 @@ using OpenRiaServices.DomainServices.Client;
 using SampleCRM.Web.Views;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-using System.Windows.Controls;
 
 namespace SampleCRM.Web.Models
 {
@@ -20,17 +19,14 @@ namespace SampleCRM.Web.Models
         private Category selectedCategory;
 
         [ObservableProperty]
-        private bool saveEnabled;
-
-        [ObservableProperty]
-        private bool rejectEnabled;
+        private bool hasChanges;
         #endregion
 
         #region Commands
 
         [RelayCommand]
-        public async Task Initialize() 
-            => await AsyncHelper.RunAsync(async () 
+        public async Task Initialize()
+            => await AsyncHelper.RunAsync(async ()
                 => CategoryCollection = (await _categoryContext.LoadAsync(_categoryContext.GetCategoriesQuery())).Entities);
 
         [RelayCommand]
@@ -44,16 +40,9 @@ namespace SampleCRM.Web.Models
         }
 
         [RelayCommand]
-        public void FormEditEnded(DataGridEditAction e) => CheckChanges();
-
-        [RelayCommand]
-        public void FormRowEditEnded(DataGridEditAction e) => CheckChanges();
-
-        private void CheckChanges()
+        public void CheckChanges()
         {
-            var hasChanges = _categoryContext.HasChanges;
-            SaveEnabled = hasChanges;
-            RejectEnabled = hasChanges;
+            HasChanges = _categoryContext.HasChanges;
         }
 
         private void OnSubmitCompleted(SubmitOperation so)
@@ -62,7 +51,7 @@ namespace SampleCRM.Web.Models
             {
                 if (so.Error.Message.StartsWith("Submit operation failed. Access to operation"))
                 {
-                    ErrorWindow.Show("Access Denied", "Insuficient User Role", so.Error.Message);
+                    ErrorWindow.Show("Access Denied", "Insufficient User Role", so.Error.Message);
                 }
                 else
                 {

--- a/src/SampleCRM/Models/Product.cs
+++ b/src/SampleCRM/Models/Product.cs
@@ -7,23 +7,29 @@ namespace SampleCRM.Web.Models
 {
     public partial class Product : Entity
     {
-        protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+        partial void OnCategoryIDChanged()
         {
-            if (e.PropertyName == nameof(CategoryID))
-            {
-                OnPropertyChanged(new PropertyChangedEventArgs(nameof(CategoryName)));
-            }
-
-            base.OnPropertyChanged(e);
+            OnPropertyChanged(new PropertyChangedEventArgs(nameof(CategoryName)));
         }
 
         public bool IsNew => string.IsNullOrEmpty(ProductID);
 
-        private IEnumerable<Category> _categoriesCombo;
+        private static IEnumerable<Category> _categoriesCombo;
         public IEnumerable<Category> CategoriesCombo
         {
-            get { return _categoriesCombo; }
-            set
+            get
+            {
+                if (_categoriesCombo == null)
+                {
+                    var context = new CategoryContext();
+                    context.Load(context.GetCategoriesQuery(), op =>
+                    {
+                        CategoriesCombo = op.Entities;
+                    }, null);
+                }
+                return _categoriesCombo;
+            }
+            private set
             {
                 if (_categoriesCombo != value)
                 {
@@ -34,7 +40,7 @@ namespace SampleCRM.Web.Models
             }
         }
 
-        public string CategoryName => CategoriesCombo.FirstOrDefault(x => x.CategoryID == CategoryID)?.Name;
+        public string CategoryName => CategoriesCombo?.FirstOrDefault(x => x.CategoryID == CategoryID)?.Name;
 
         public string PictureUrl
         {

--- a/src/SampleCRM/Models/Product.cs
+++ b/src/SampleCRM/Models/Product.cs
@@ -1,4 +1,5 @@
 ﻿using OpenRiaServices.DomainServices.Client;
+using SampleCRM.Web.Views;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -25,7 +26,7 @@ namespace SampleCRM.Web.Models
                     context.Load(context.GetCategoriesQuery(), op =>
                     {
                         CategoriesCombo = op.Entities;
-                    }, null);
+                    });
                 }
                 return _categoriesCombo;
             }

--- a/src/SampleCRM/Models/ProductsPageVM.cs
+++ b/src/SampleCRM/Models/ProductsPageVM.cs
@@ -57,7 +57,7 @@ namespace SampleCRM.Web.Models
         {
             var result = await ProductsAddEditWindow.Show(SelectedProduct, _productsContext);
             if (result)
-                await AsyncHelper.RunAsync(LoadProducts);
+                LoadProducts();
         }
 
         private async void GetProductPicture_Completed(InvokeOperation<byte[]> operation)
@@ -75,20 +75,20 @@ namespace SampleCRM.Web.Models
 
         #endregion
 
-        #region Commands
-        [RelayCommand]
-        public async Task Initialize()
+        public ProductsPageVM()
         {
-            await AsyncHelper.RunAsync(LoadProducts);
+            LoadProducts();
         }
 
+        #region Commands
         [RelayCommand]
-        public async Task LoadProducts()
+        public void LoadProducts()
         {
             var query = _productsContext.GetProductsQuery(SearchText).OrderBy(c => c.Name);
-            var result = await _productsContext.LoadAsync(query);
-
-            ProdcutsView = new PagedCollectionView(result.Entities);
+            _productsContext.Load(query, result =>
+            {
+                ProdcutsView = new PagedCollectionView(result.Entities);
+            });
         }
 
         [RelayCommand]
@@ -101,14 +101,14 @@ namespace SampleCRM.Web.Models
             }, _productsContext);
 
             if (result)
-                await AsyncHelper.RunAsync(LoadProducts);
+                LoadProducts();
         }
 
         [RelayCommand]
-        public async Task SearchCancel()
+        public void SearchCancel()
         {
             SearchText = string.Empty;
-            await AsyncHelper.RunAsync(LoadProducts);
+            LoadProducts();
         }
 
         #endregion

--- a/src/SampleCRM/Models/ProductsPageVM.cs
+++ b/src/SampleCRM/Models/ProductsPageVM.cs
@@ -3,7 +3,6 @@ using CommunityToolkit.Mvvm.Input;
 using OpenRiaServices.DomainServices.Client;
 using SampleCRM.Web.Views;
 using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +14,6 @@ namespace SampleCRM.Web.Models
     {
         #region Properties
         private readonly ProductsContext _productsContext = new();
-        private readonly CategoryContext _categoryContext = new();
 
         private ICollectionView _productsView;
         public ICollectionView ProdcutsView
@@ -29,9 +27,6 @@ namespace SampleCRM.Web.Models
 
         [ObservableProperty]
         private string searchText = string.Empty;
-
-        [ObservableProperty]
-        private IEnumerable<Models.Category> categoriesCombo;
 
         #endregion
 
@@ -51,9 +46,6 @@ namespace SampleCRM.Web.Models
 #endif
             if (SelectedProduct != null && isUserSelectedProduct)
             {
-                if (SelectedProduct.CategoriesCombo == null)
-                    SelectedProduct.CategoriesCombo = CategoriesCombo;
-
                 if (SelectedProduct.Picture == null || SelectedProduct.Picture.Length < 2)
                     _productsContext.GetProductPicture(SelectedProduct.ProductID, GetProductPicture_Completed, null);
                 else
@@ -87,7 +79,6 @@ namespace SampleCRM.Web.Models
         [RelayCommand]
         public async Task Initialize()
         {
-            await AsyncHelper.RunAsync(LoadCategoriesCombo);
             await AsyncHelper.RunAsync(LoadProducts);
         }
 
@@ -98,19 +89,13 @@ namespace SampleCRM.Web.Models
             var result = await _productsContext.LoadAsync(query);
 
             ProdcutsView = new PagedCollectionView(result.Entities);
-
-            foreach (var product in result.Entities)
-                product.CategoriesCombo = CategoriesCombo;
         }
-
-        private async Task LoadCategoriesCombo() => CategoriesCombo = (await _categoryContext.LoadAsync(_categoryContext.GetCategoriesQuery())).Entities;
 
         [RelayCommand]
         public async Task NewProduct()
         {
             var result = await ProductsAddEditWindow.Show(new Product
             {
-                CategoriesCombo = CategoriesCombo,
                 CreatedOnUTC = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
                 LastModifiedOnUTC = DateTimeOffset.UtcNow.ToUnixTimeSeconds()
             }, _productsContext);

--- a/src/SampleCRM/Views/Categories.xaml
+++ b/src/SampleCRM/Views/Categories.xaml
@@ -81,18 +81,16 @@
                     </DataGrid.Columns>
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="RowEditEnded">
-                            <i:InvokeCommandAction Command="{Binding FormRowEditEndedCommand}"
-                                                   PassEventArgsToCommand="True" EventArgsParameterPath="EditAction"/>
+                            <i:InvokeCommandAction Command="{Binding CheckChangesCommand}"/>
                         </i:EventTrigger>
                         <i:EventTrigger EventName="EditEnded">
-                            <i:InvokeCommandAction Command="{Binding FormEditEndedCommand}"
-                                                   PassEventArgsToCommand="True" EventArgsParameterPath="EditAction"/>
+                            <i:InvokeCommandAction Command="{Binding CheckChangesCommand}"/>
                         </i:EventTrigger>
                     </i:Interaction.Triggers>
                 </DataGrid>
                 <StackPanel HorizontalAlignment="Left" Orientation="Horizontal" Grid.Row="2">
                     <Button x:Name="SaveButton" 
-                            IsEnabled="{Binding SaveEnabled}"
+                            IsEnabled="{Binding HasChanges}"
                             Command="{Binding SaveCommand}" 
                             Style="{StaticResource PrimaryButtonStyle}" Margin="0,0,10,0">
                         <StackPanel Style="{StaticResource ButtonPanelStyle}">
@@ -101,7 +99,7 @@
                         </StackPanel>
                     </Button>
                     <Button x:Name="RejectButton" 
-                            IsEnabled="{Binding RejectEnabled}"
+                            IsEnabled="{Binding HasChanges}"
                             Command="{Binding RejectCommand}"   
                             Style="{StaticResource SecondaryButtonStyle}" >
                         <StackPanel Style="{StaticResource ButtonPanelStyle}">

--- a/src/SampleCRM/Views/Products.xaml
+++ b/src/SampleCRM/Views/Products.xaml
@@ -4,19 +4,9 @@
                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
-                xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity" 
                 xmlns:models="clr-namespace:SampleCRM.Web.Models"
                 mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="480"
                 Style="{StaticResource PageStyle}">
-    <local:BasePage.Resources>
-        
-    </local:BasePage.Resources>
-
-    <i:Interaction.Triggers>
-        <i:EventTrigger EventName="Loaded">
-            <i:InvokeCommandAction Command="{Binding InitializeCommand}"/>
-        </i:EventTrigger>
-    </i:Interaction.Triggers>
 
     <local:BasePage.DataContext>
         <models:ProductsPageVM/>


### PR DESCRIPTION
- Simplified a bit categories viewmodel
- Viewmodels load collections that are used only in child models. For example, products viewmodel contained CategoriesCombo and assigned it to Product.CategoriesCombo. Instead I think we can store the CategoriesCombo only in Product and make it static. The same way we could get rid of CountryCodes, Shippers and so on collections from orders viewmodel.
- We can remove InitializeCommand and load collections from viewmodel constructor by using sync Load method and callback.
- Probably it is better to create viewmodel wrappers around models (for example CustomerVM instead of partial Customer class), to separate data layer and use MVVMToolkit features. But seems like it's a lot of work and need to check which properties are used in xaml
- Also we could use VisualStates for mobile views instead of conditions in code behind