### PR TITLE
Make default visual states empty

### DIFF
--- a/src/SampleCRM/Views/Customers.xaml
+++ b/src/SampleCRM/Views/Customers.xaml
@@ -224,67 +224,6 @@
         <VisualStateGroup x:Name="AdaptiveVisualStateGroup">
             <VisualState x:Name="DefaultState">
                 <Storyboard>
-                    <!-- Adjustments for grdHead layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdHead" Storyboard.TargetProperty="(Grid.ColumnDefinitions)[2].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="305"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Adjustments for grdSearch layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch" Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch" Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Since ThicknessAnimationUsingKeyFrames is not available, we will not animate the margin, but set it directly in XAML when this state is active -->
-                    <!-- This will be set outside of storyboard as a visual state setter if needed -->
-
-                    <!-- Adjustments for customerCard layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="customerCard" Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="customerCard" Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Adjustments for grdCustomerDetails layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdCustomerDetails" Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdCustomerDetails" Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Adjustments for grdTbCustomer layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbCustomer" Storyboard.TargetProperty="(Grid.RowDefinitions)[0].Height">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2*"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbCustomer" Storyboard.TargetProperty="(Grid.RowDefinitions)[1].Height">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="Auto"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbCustomer" Storyboard.TargetProperty="(Grid.ColumnDefinitions)[0].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2*"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbCustomer" Storyboard.TargetProperty="(Grid.ColumnDefinitions)[1].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="4*"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Change DataTemplate for formCustomer -->
-                    <!--<ObjectAnimationUsingKeyFrames Storyboard.TargetName="formCustomer" Storyboard.TargetProperty="EditTemplate">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource dtWideCustomers}"/>
-                    </ObjectAnimationUsingKeyFrames>-->
-
-                    <!-- Adjustments for grdTbOrders layout -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrders" Storyboard.TargetProperty="(Grid.ColumnDefinitions)[2].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="305"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderSearch" Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderSearch" Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
                 </Storyboard>
             </VisualState>
             <VisualState x:Name="MobileState">
@@ -467,9 +406,13 @@
             <TabItem x:Name="tbCustomer" Header="Customer" Style="{StaticResource MaterialDesign_TabItem_Style}">
                 <ScrollViewer x:Name="scrTbCustomer" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" BorderThickness="0">
                     <Grid x:Name="grdTbCustomer">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition x:Name="colDefGrdTbCustomer0" Width="*"/>
-                            <ColumnDefinition x:Name="colDefGrdTbCustomer1" Width="2*"/>
+                            <ColumnDefinition x:Name="colDefGrdTbCustomer1" Width="4*"/>
                         </Grid.ColumnDefinitions>
                         <Border x:Name="customerCard" Grid.Column="0" Background="{StaticResource CustomerCardBackground}" 
                                 DataContext="{Binding SelectedCustomer, Mode=OneWay}">
@@ -581,7 +524,7 @@
                         </StackPanel>
                     </Button>
 
-                    <Grid x:Name="grdOrderSearch" Grid.Column="3" Grid.Row="0" Grid.ColumnSpan="3" >
+                    <Grid x:Name="grdOrderSearch" Grid.Column="2" Grid.Row="0" Grid.ColumnSpan="3" >
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="16" />

--- a/src/SampleCRM/Views/Dashboard.xaml
+++ b/src/SampleCRM/Views/Dashboard.xaml
@@ -18,46 +18,6 @@
             <VisualStateGroup x:Name="AdaptiveVisualStateGroup">
                 <VisualState x:Name="DefaultState">
                     <Storyboard>
-                        <!-- Reset to default layout for wider screens -->
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="cntCustomers">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="cntOrders">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Column)" Storyboard.TargetName="cntProducts">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Row)" Storyboard.TargetName="cntCustomers">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Row)" Storyboard.TargetName="cntOrders">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="(Grid.Row)" Storyboard.TargetName="cntProducts">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                        </ObjectAnimationUsingKeyFrames>
-
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Width" Storyboard.TargetName="columnDef0">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="1*"/>
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Width" Storyboard.TargetName="columnDef1">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="20" />
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Width" Storyboard.TargetName="columnDef2">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="1*" />
-                        </ObjectAnimationUsingKeyFrames>
-
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="rowDef0" Storyboard.TargetProperty="Height">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="300" />
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="rowDef1" Storyboard.TargetProperty="Height">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="400" />
-                        </ObjectAnimationUsingKeyFrames>
-                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="rowDef2" Storyboard.TargetProperty="Height">
-                            <DiscreteObjectKeyFrame KeyTime="0" Value="Auto" />
-                        </ObjectAnimationUsingKeyFrames>
-
                     </Storyboard>
                 </VisualState>
                 <VisualState x:Name="MobileState">

--- a/src/SampleCRM/Views/Orders.xaml
+++ b/src/SampleCRM/Views/Orders.xaml
@@ -261,80 +261,6 @@
         <VisualStateGroup x:Name="AdaptiveVisualStateGroup">
             <VisualState x:Name="DefaultState">
                 <Storyboard>
-                    <!-- Set column width back to original for default state -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdHead"
-                                       Storyboard.TargetProperty="(Grid.ColumnDefinitions)[2].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="305"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Set the position of the search grid back to its default state -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch"
-                                       Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch"
-                                       Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Reset positions for order card -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="orderCard"
-                                       Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="orderCard"
-                                       Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Reset positions and sizes for order details grid -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderDetails"
-                                       Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderDetails"
-                                       Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Set row heights back to original for default state -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrder"
-                                       Storyboard.TargetProperty="(Grid.RowDefinitions)[0].Height">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2*"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrder"
-                                       Storyboard.TargetProperty="(Grid.RowDefinitions)[1].Height">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="Auto"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Set column widths back to original for default state -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrder"
-                                       Storyboard.TargetProperty="(Grid.ColumnDefinitions)[0].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2*"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrder"
-                                       Storyboard.TargetProperty="(Grid.ColumnDefinitions)[1].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="4*"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Update DataTemplate for formOrder -->
-                    <!-- Note: Just as with the MobileState, changing the DataTemplate is not standard in VisualState animations and might need to be handled differently depending on your environment. -->
-
-                    <!-- Reset column width for order items section -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdTbOrderItems"
-                                       Storyboard.TargetProperty="(Grid.ColumnDefinitions)[2].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="305"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Reset position of the order item search grid -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderItemSearch"
-                                       Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdOrderItemSearch"
-                                       Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
                 </Storyboard>
             </VisualState>
             <VisualState x:Name="MobileState">
@@ -506,9 +432,13 @@
             <TabItem x:Name="tbOrder" Header="Order" Style="{StaticResource MaterialDesign_TabItem_Style}">
                 <ScrollViewer x:Name="scrTbOrder" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled" BorderThickness="0">
                     <Grid x:Name="grdTbOrder">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="2*"/>
+                            <RowDefinition Height="Auto"/>
+                        </Grid.RowDefinitions>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*"/>
-                            <ColumnDefinition Width="2*"/>
+                            <ColumnDefinition Width="4*"/>
                         </Grid.ColumnDefinitions>
                         <Border x:Name="orderCard" Grid.Column="0" 
                                 Background="{StaticResource CustomerCardBackground}" 
@@ -616,7 +546,7 @@
                         </StackPanel>
                     </Button>
 
-                    <Grid x:Name="grdOrderItemSearch" Grid.Column="3" Grid.Row="0" Grid.ColumnSpan="3" >
+                    <Grid x:Name="grdOrderItemSearch" Grid.Column="2" Grid.Row="0" Grid.ColumnSpan="3" >
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
                             <ColumnDefinition Width="16" />

--- a/src/SampleCRM/Views/Products.xaml
+++ b/src/SampleCRM/Views/Products.xaml
@@ -17,25 +17,6 @@
             <!-- DefaultState definition -->
             <VisualState x:Name="DefaultState">
                 <Storyboard>
-                    <!-- Set the third column width back to 305 pixels -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdHead" 
-                                               Storyboard.TargetProperty="(Grid.ColumnDefinitions)[2].Width">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="305"/>
-                    </ObjectAnimationUsingKeyFrames>
-
-                    <!-- Position the search grid back to its original location -->
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch" 
-                                               Storyboard.TargetProperty="(Grid.Column)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="2"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch" 
-                                               Storyboard.TargetProperty="(Grid.Row)">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
-                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="grdSearch" 
-                                               Storyboard.TargetProperty="Margin">
-                        <DiscreteObjectKeyFrame KeyTime="0" Value="0"/>
-                    </ObjectAnimationUsingKeyFrames>
                 </Storyboard>
             </VisualState>
 


### PR DESCRIPTION
The `DefaultState` can be empty. We should set default values in xaml, no need to duplicate them in the state